### PR TITLE
Add checker in order to start authentication when configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ yarn install
 npm start dev
 ```
 
-:warning: Change `.env.local`to `.env`
+:warning: Change `.env.local` to `.env`

--- a/server.js
+++ b/server.js
@@ -9,11 +9,12 @@ dotenv.config();
 
 const logger = require('./utils/logger');
 const { apiErrorHandler, resourceNotFoundHandler, isAuthenticated } = require('./utils/express-middleware');
+const { hasAuthentication } = require('./utils/common');
 
 const api = require('./api');
-const auth = require('./auth');
 
 const app = express();
+const serverLogger = logger('server');
 
 app.use(session({
     secret: process.env.APP_SESSION_SALT,
@@ -22,7 +23,12 @@ app.use(session({
     saveUninitialized: true
 }));
 
-auth(app);
+if (hasAuthentication()) {
+    const auth = require('./auth');
+
+    serverLogger.info('Server started with authentication configured');
+    auth(app);
+}
 
 // Add some basic security
 app.use(helmet());
@@ -46,4 +52,4 @@ const port = process.env.APP_SERVER_PORT || 3000; // set our port
 // Start the server
 app.listen(port);
 
-logger('server').info(`trackovid-19 server started on port ${port}`);
+serverLogger.info(`trackovid-19 server started on port ${port}`);

--- a/utils/common.js
+++ b/utils/common.js
@@ -1,0 +1,13 @@
+function hasFacebookCredentials () {
+    return process.env.FB_APP_ID !== undefined &&
+        process.env.FB_APP_SECRET !== undefined &&
+        process.env.FB_CALLBACK_URL !== undefined;
+}
+
+function hasAuthentication () {
+   return hasFacebookCredentials();
+}
+
+module.exports = {
+    hasAuthentication
+};

--- a/utils/express-middleware.js
+++ b/utils/express-middleware.js
@@ -1,6 +1,7 @@
 const logger = require('./logger');
 const HTTP_STATUS_CODE = require('../enums/http-status-code');
 const API_ERRORS = require('../enums/api-errors');
+const { hasAuthentication } = require('../utils/common');
 
 /**
  * Handles the unexpected API errors
@@ -50,7 +51,7 @@ function resourceNotFoundHandler (req, res, next) {
  * with the unauthorized status code.
  */
 function isAuthenticated (req, res, next) {
-    if (req.isAuthenticated() || process.env.MOCK_SERVICES === "true") {
+    if (req.isAuthenticated() || !hasAuthentication() || process.env.MOCK_SERVICES === "true") {
         next();
     } else {
         logger('express-middleware-auth').info(


### PR DESCRIPTION
In this commit was added the capability of run this server
when the user doesn't configured the facebook oauth service
and this should be acessible without anykind of authentication.

NOTE: This should be used only in dev mode