### PR TITLE
Improve instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 # trackovid19-backend
 
-
-
 # Install dependencies
 
 ```
-npm install
+$ npm install
 
 OR
 
-yarn install
+$ yarn install
 ```
 
-# Start server
+# Start server locally
+
+Copy `.env.local` to `.env` and set something in the `APP_SESSION_SALT` env var
+(for example, `covid-19`). If you want to run the mock API, also set
+`MOCK_SERVICES=true`.
+
+Having the `.env` file correctly setup, the following should start the server
+locally:
 
 ```
-npm start dev
+$ npm start dev
 ```
-
-:warning: Change `.env.local`to `.env`


### PR DESCRIPTION
This PR improves the instructions to start the server locally. Namely, it adds a mention to the `APP_SESSION_SALT` and `MOCK_SERVICES` environment variables.