### PR TITLE
Replace npm with yarn in pipeline

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,8 +24,8 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build --if-present
-#    - run: npm test
+    - run: yarn install
+    - run: yarn run build
+#    - run: yarn test
       env:
         CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn install
-    - run: yarn run build
 #    - run: yarn test
       env:
         CI: true


### PR DESCRIPTION
Fixes following error in pipeline:
```
npm ERR! cipm can only install packages with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or later to generate it, then try again.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2020-03-18T04_19_31_279Z-debug.log
##[error]Process completed with exit code 1.
```