### PR TITLE
Returning postalcode description (municipality list)

### DIFF
--- a/controllers/v1/user/index.js
+++ b/controllers/v1/user/index.js
@@ -19,6 +19,10 @@ module.exports = async (fastify, opts) => {
           {
             model: fastify.models().Case,
             as: 'latest_status'
+          },
+          {
+            model: fastify.models().PostalCodeDescriptions,
+            as: 'pc_description'
           }
         ],
         ...publicAttributes

--- a/db/migrations/009.postal_codes_view.sql
+++ b/db/migrations/009.postal_codes_view.sql
@@ -1,0 +1,75 @@
+--
+-- For retrieving postal code description by postal_number
+--
+create or replace view public.postal_code_descriptions AS
+ select pc.postal_number, string_agg(pc.municipality_name, ', ' order by pc.municipality_name) as description
+from (
+	select ppc.postal_number, ppc.municipality_name
+	from public.pt_postal_codes ppc
+	group by ppc.postal_number, ppc.municipality_name
+) pc
+group by pc.postal_number;
+
+alter table public.postal_code_descriptions owner to postgres;
+
+create or replace view public.status_by_postalcode
+as
+select sview.postalcode1, sview.status, sview.status_text, sview.summary_order, sview.hits, pcd.description as postalcode_description
+from 
+(
+    select us.postalcode1, us.id as status, us.status_summary as status_text, us.summary_order, count(h.*) as hits
+    from public.history h
+    inner join public.latest_status ls on ls.user_id = h.user_id and ls.history_id = h.id
+    right outer join (
+        select * 
+        from (
+            select distinct h.postalcode1
+            from public.history h
+        ) hh
+        cross join (
+            select *
+            from public.user_status users
+            where users.show_in_summary = true
+        ) us
+    ) us on us.id = h.status and us.postalcode1 = h.postalcode1
+    group by us.postalcode1, us.id, us.status_summary, us.summary_order
+    union all
+    select h.postalcode1, case when us.has_symptoms then 100 else 200 end as status, case when us.has_symptoms then 'Com sintomas' else 'Sem sintomas' end as status_text, case when us.has_symptoms then 5 else 6 end as summary_order, count(h.*) as hits
+    from public.history h
+    inner join public.latest_status ls on ls.user_id = h.user_id and ls.history_id = h.id
+    inner join (
+        select uus.history_id, min(uus.symptom_id), case when min(uus.symptom_id) = 1 then false else true end as has_symptoms
+        from public.user_symptoms uus
+        group by uus.history_id
+    ) us on us.history_id = h.id
+    where h.postalcode1 is not null
+    group by h.postalcode1, us.has_symptoms
+) sview
+inner join public.postal_code_descriptions pcd on pcd.postal_number = sview.postalcode1;
+
+
+create or replace view public.confinement_states_by_postalcode
+as
+select sview.postalcode1, sview.confinement_state, sview.confinement_state_text, sview.summary_order, sview.hits, pcd.description as postalcode_description
+from (
+    select con.postalcode1, con.confinement_state, con.state_summary as confinement_state_text, con.summary_order, sum(con.hit_value) as hits
+    from (
+        select cs.postalcode1, case when cs.id in (2, 3) then 300 else cs.id end as confinement_state, cs.state_summary, cs.summary_order, case when h.confinement_state is not null then 1 else 0 end as hit_value
+        from public.history h
+        inner join public.latest_status ls on ls.user_id = h.user_id and ls.history_id = h.id
+        right outer join (
+            select * 
+            from (
+                select distinct h.postalcode1
+                from public.history h
+            ) hh
+            cross join (
+                select *
+                from public.confinement_states cons
+                where cons.show_in_summary =  true
+            ) cs
+        ) cs on cs.id = h.confinement_state and cs.postalcode1 = h.postalcode1
+    ) as con
+    group by con.postalcode1, con.confinement_state, con.state_summary, con.summary_order
+) sview 
+inner join public.postal_code_descriptions pcd on pcd.postal_number = sview.postalcode1;;

--- a/db/migrations/009.postal_codes_view.sql
+++ b/db/migrations/009.postal_codes_view.sql
@@ -1,60 +1,23 @@
---
--- For retrieving postal code description by postal_number
---
-create or replace view public.postal_code_descriptions AS
- select pc.postal_number, string_agg(pc.municipality_name, ', ' order by pc.municipality_name) as description
-from (
-	select ppc.postal_number, ppc.municipality_name
-	from public.pt_postal_codes ppc
-	group by ppc.postal_number, ppc.municipality_name
-) pc
-group by pc.postal_number;
-
-alter table public.postal_code_descriptions owner to postgres;
-
-create or replace view public.status_by_postalcode
-as
-select sview.postalcode1, sview.status, sview.status_text, sview.summary_order, sview.hits, pcd.description as postalcode_description
-from 
-(
-    select us.postalcode1, us.id as status, us.status_summary as status_text, us.summary_order, count(h.*) as hits
-    from public.history h
-    inner join public.latest_status ls on ls.user_id = h.user_id and ls.history_id = h.id
-    right outer join (
-        select * 
-        from (
-            select distinct h.postalcode1
-            from public.history h
-        ) hh
-        cross join (
-            select *
-            from public.user_status users
-            where users.show_in_summary = true
-        ) us
-    ) us on us.id = h.status and us.postalcode1 = h.postalcode1
-    group by us.postalcode1, us.id, us.status_summary, us.summary_order
-    union all
-    select h.postalcode1, case when us.has_symptoms then 100 else 200 end as status, case when us.has_symptoms then 'Com sintomas' else 'Sem sintomas' end as status_text, case when us.has_symptoms then 5 else 6 end as summary_order, count(h.*) as hits
-    from public.history h
-    inner join public.latest_status ls on ls.user_id = h.user_id and ls.history_id = h.id
-    inner join (
-        select uus.history_id, min(uus.symptom_id), case when min(uus.symptom_id) = 1 then false else true end as has_symptoms
-        from public.user_symptoms uus
-        group by uus.history_id
-    ) us on us.history_id = h.id
-    where h.postalcode1 is not null
-    group by h.postalcode1, us.has_symptoms
-) sview
-inner join public.postal_code_descriptions pcd on pcd.postal_number = sview.postalcode1;
-
-
-create or replace view public.confinement_states_by_postalcode
-as
-select sview.postalcode1, sview.confinement_state, sview.confinement_state_text, sview.summary_order, sview.hits, pcd.description as postalcode_description
-from (
-    select con.postalcode1, con.confinement_state, con.state_summary as confinement_state_text, con.summary_order, sum(con.hit_value) as hits
+    --
+    -- For retrieving postal code description by postal_number
+    --
+    create or replace view public.postal_code_descriptions AS
+    select pc.postal_number, string_agg(pc.municipality_name, ', ' order by pc.municipality_name) as description
     from (
-        select cs.postalcode1, case when cs.id in (2, 3) then 300 else cs.id end as confinement_state, cs.state_summary, cs.summary_order, case when h.confinement_state is not null then 1 else 0 end as hit_value
+        select ppc.postal_number, ppc.municipality_name
+        from public.pt_postal_codes ppc
+        group by ppc.postal_number, ppc.municipality_name
+    ) pc
+    group by pc.postal_number;
+
+    alter table public.postal_code_descriptions owner to postgres;
+
+    create or replace view public.status_by_postalcode
+    as
+    select sview.postalcode1, sview.status, sview.status_text, sview.summary_order, sview.hits, pcd.description as postalcode_description, sview.latest_status_ts
+    from 
+    (
+        select us.postalcode1, us.id as status, us.status_summary as status_text, us.summary_order, count(h.*) as hits, max(ls.timestamp) as latest_status_ts
         from public.history h
         inner join public.latest_status ls on ls.user_id = h.user_id and ls.history_id = h.id
         right outer join (
@@ -65,11 +28,48 @@ from (
             ) hh
             cross join (
                 select *
-                from public.confinement_states cons
-                where cons.show_in_summary =  true
-            ) cs
-        ) cs on cs.id = h.confinement_state and cs.postalcode1 = h.postalcode1
-    ) as con
-    group by con.postalcode1, con.confinement_state, con.state_summary, con.summary_order
-) sview 
-inner join public.postal_code_descriptions pcd on pcd.postal_number = sview.postalcode1;;
+                from public.user_status users
+                where users.show_in_summary = true
+            ) us
+        ) us on us.id = h.status and us.postalcode1 = h.postalcode1
+        group by us.postalcode1, us.id, us.status_summary, us.summary_order
+        union all
+        select h.postalcode1, case when us.has_symptoms then 100 else 200 end as status, case when us.has_symptoms then 'Com sintomas' else 'Sem sintomas' end as status_text, case when us.has_symptoms then 5 else 6 end as summary_order, count(h.*) as hits, max(ls.timestamp) as latest_status_ts
+        from public.history h
+        inner join public.latest_status ls on ls.user_id = h.user_id and ls.history_id = h.id
+        inner join (
+            select uus.history_id, min(uus.symptom_id), case when min(uus.symptom_id) = 1 then false else true end as has_symptoms
+            from public.user_symptoms uus
+            group by uus.history_id
+        ) us on us.history_id = h.id
+        where h.postalcode1 is not null
+        group by h.postalcode1, us.has_symptoms
+    ) sview
+    inner join public.postal_code_descriptions pcd on pcd.postal_number = sview.postalcode1;
+
+
+    create or replace view public.confinement_states_by_postalcode
+    as
+    select sview.postalcode1, sview.confinement_state, sview.confinement_state_text, sview.summary_order, sview.hits, pcd.description as postalcode_description, sview.latest_status_ts
+    from (
+        select con.postalcode1, con.confinement_state, con.state_summary as confinement_state_text, con.summary_order, sum(con.hit_value) as hits, max(con.timestamp) as latest_status_ts
+        from (
+            select cs.postalcode1, case when cs.id in (2, 3) then 300 else cs.id end as confinement_state, cs.state_summary, cs.summary_order, case when h.confinement_state is not null then 1 else 0 end as hit_value, ls.timestamp
+            from public.history h
+            inner join public.latest_status ls on ls.user_id = h.user_id and ls.history_id = h.id
+            right outer join (
+                select * 
+                from (
+                    select distinct h.postalcode1
+                    from public.history h
+                ) hh
+                cross join (
+                    select *
+                    from public.confinement_states cons
+                    where cons.show_in_summary =  true
+                ) cs
+            ) cs on cs.id = h.confinement_state and cs.postalcode1 = h.postalcode1
+        ) as con
+        group by con.postalcode1, con.confinement_state, con.state_summary, con.summary_order
+    ) sview 
+    inner join public.postal_code_descriptions pcd on pcd.postal_number = sview.postalcode1;

--- a/db/models/confinement_state_by_postalcode.js
+++ b/db/models/confinement_state_by_postalcode.js
@@ -17,6 +17,10 @@ module.exports = function(sequelize, DataTypes) {
 				key: 'id'
 			}
 		},
+		postalcode_description: {
+			type: DataTypes.STRING,
+			allowNull: true
+		},
 		confinement_state_text: {
 			type: DataTypes.STRING,
 			allowNull: true

--- a/db/models/postal_code_descriptions.js
+++ b/db/models/postal_code_descriptions.js
@@ -1,0 +1,18 @@
+/* jshint indent: 1 */
+
+module.exports = function(sequelize, DataTypes) {
+	return sequelize.define('postal_code_descriptions', {
+		postal_number: {
+			type: DataTypes.STRING,
+            allowNull: true,
+            primaryKey: true
+		},
+        description: {
+			type: DataTypes.STRING,
+            allowNull: true
+		}
+	}, {
+		tableName: 'postal_code_descriptions',
+		timestamps: false
+	});
+};

--- a/db/models/status_by_postalcode.js
+++ b/db/models/status_by_postalcode.js
@@ -16,7 +16,11 @@ module.exports = function(sequelize, DataTypes) {
 				model: 'user_status',
 				key: 'id'
 			}
-        },
+		},
+		postalcode_description: {
+			type: DataTypes.STRING,
+			allowNull: true
+		},
         status_text: {
 			type: DataTypes.STRING,
             allowNull: true

--- a/db/models/users.js
+++ b/db/models/users.js
@@ -50,7 +50,11 @@ module.exports = function(sequelize, DataTypes) {
 		},
 		postalcode1: {
 			type: DataTypes.STRING,
-			allowNull: true
+			allowNull: true,
+			references: {
+				model: 'postal_code_descriptions',
+				key: 'postal_number'
+			}
 		},
 		postalcode2: {
 			type: DataTypes.STRING,

--- a/docker/database/tracovid.yml
+++ b/docker/database/tracovid.yml
@@ -10,6 +10,7 @@ services:
       - "54320:5432"
     volumes:
       - tracovid_data:/var/lib/postgresql/data
+      - ../../db:/guestfiles
     environment:
       POSTGRES_USER: tracovid 
       POSTGRES_PASSWORD: tracovid

--- a/plugins/models.js
+++ b/plugins/models.js
@@ -15,8 +15,9 @@ module.exports = fp(async (fastify, opts) => {
         const VideoShares = fastify.sequelize.import('../db/models/video_shares.js');
         const Videos = fastify.sequelize.import('../db/models/videos.js');
         const PushSubscriptions = fastify.sequelize.import('../db/models/push_subscriptions.js');
+        const PostalCodeDescriptions = fastify.sequelize.import('../db/models/postal_code_descriptions.js');
 
-        return { Case, Network, Users, UsersData, Symptom, ConfinementState, Condition, StatusByPostalCode, ConfinementStateByPostalCode, UserSymptom, Videos, VideoShares, PushSubscriptions };
+        return { Case, Network, Users, UsersData, Symptom, ConfinementState, Condition, StatusByPostalCode, ConfinementStateByPostalCode, UserSymptom, Videos, VideoShares, PushSubscriptions, PostalCodeDescriptions };
         
     })
 
@@ -24,16 +25,12 @@ module.exports = fp(async (fastify, opts) => {
         const Case = fastify.sequelize.import('../db/models/history.js');
         const Network = fastify.sequelize.import('../db/models/network.js');
         const Users = fastify.sequelize.import('../db/models/users.js');
-        const UsersData = fastify.sequelize.import('../db/models/users_data.js');
         const Symptom = fastify.sequelize.import('../db/models/symptoms.js');
         const UserSymptom = fastify.sequelize.import('../db/models/user_symptoms.js');
-        const ConfinementState = fastify.sequelize.import('../db/models/confinement_states.js');
-        const Condition = fastify.sequelize.import('../db/models/user_status.js');
-        const StatusByPostalCode = fastify.sequelize.import('../db/models/status_by_postalcode.js');
-        const ConfinementStateByPostalCode = fastify.sequelize.import('../db/models/confinement_state_by_postalcode.js');
         const VideoShares = fastify.sequelize.import('../db/models/video_shares.js');
         const Videos = fastify.sequelize.import('../db/models/videos.js');
         const PushSubscriptions = fastify.sequelize.import('../db/models/push_subscriptions.js');
+        const PostalCodeDescriptions = fastify.sequelize.import('../db/models/postal_code_descriptions.js');
 
         console.log('Initializing models');
 
@@ -42,6 +39,8 @@ module.exports = fp(async (fastify, opts) => {
         Users.hasMany(Case, { foreignKey: 'user_id', as: 'cases' });
 
         Users.belongsTo(Case, { foreignKey: 'latest_status_id', as: 'latest_status' })
+        
+        Users.belongsTo(PostalCodeDescriptions, { foreignKey: 'postalcode1', as: 'pc_description' })
         
         Users.hasMany(Network, { foreignKey: 'user_id' });
         Network.belongsTo(Users, { foreignKey: 'user_id' });


### PR DESCRIPTION
Created an association between users and postal_code_descriptions (new view) in order to enhance the user information with the municipality name of the postal_number (first 4 digits). The current implementation adds a `pc_description` object to the users object, in the form:
`{
"postal_number": 4200,
"description": "Porto"
}`

This approach is not optimal since it duplicates (again) the postal code but I couldn't find a way to define an association in sequelize, then use it and finally erase the resultant attribute from the fetched object (solutions are welcome).

I've also changed the views that feed the dashboard for retrieving the same information in a new `postalcode_decription` attribute along with the respective endpoints.

Closes #124.