### PR TITLE
fixing share db persistency

### DIFF
--- a/controllers/v1/share/index.js
+++ b/controllers/v1/share/index.js
@@ -32,7 +32,10 @@ module.exports = async (fastify) => {
             const myHash = caseHash.digest('hex')
 
             let res = await fastify.models().ShareImagesByPostalcode.findOne({
-                where: {image_hash: myHash},
+                where: {
+                    image_hash: myHash, 
+                    postalcode: postparts[0]
+                },
             })
             if (!res) {
                 let data = {}
@@ -73,10 +76,9 @@ module.exports = async (fastify) => {
                 console.log('data object: ', data);
                 let buffer = await imgGeneratorService.dashboard(data)
 
-                let fileKey = await awsService.S3.storeS3(buffer,
-                    myHash + '.png')
+                let fileKey = await awsService.S3.storeS3(buffer, myHash + '.png')
                 const fileUrl = process.env.AWS_S3_DOMAIN + '/' + fileKey
-
+                
                 fastify.models().
                     ShareImagesByPostalcode.
                     create({

--- a/db/migrations/011.share_images_by_postalcode.sql
+++ b/db/migrations/011.share_images_by_postalcode.sql
@@ -1,9 +1,11 @@
+drop table if exists public.share_images_by_postalcode;
+
 create TABLE public.share_images_by_postalcode
 (
     postalcode1 character varying(4) COLLATE pg_catalog."default" NOT NULL,
     image_hash character varying(256) COLLATE pg_catalog."default",
     image_url character varying(265) COLLATE pg_catalog."default",
-    CONSTRAINT share_images_by_postalcode_pk PRIMARY KEY (postalcode1)
+    CONSTRAINT share_images_by_postalcode_pk PRIMARY KEY (postalcode1, image_hash)
 );
 
 alter table public.share_images_by_postalcode


### PR DESCRIPTION
The pk of the share images table was not taking the hash into account. That's fixed now.